### PR TITLE
Added port to config and java classes

### DIFF
--- a/config/plugin.json
+++ b/config/plugin.json
@@ -2,7 +2,8 @@
   "agents": [
       {
           "name": "Apache offical",
-          "host": "apache.org"
+          "host": "apache.org",
+          "port": "80"
       }
 
   ]

--- a/src/com/mblund/newRelic/apacheHttpd/ApacheHttpdAgent.java
+++ b/src/com/mblund/newRelic/apacheHttpd/ApacheHttpdAgent.java
@@ -42,11 +42,11 @@ public class ApacheHttpdAgent extends Agent {
      * @param host
      * @throws ConfigurationException if URL for Apache httpd's mod_status service could not be built correctly from provided host
      */
-    public ApacheHttpdAgent(String name, String host) throws ConfigurationException {
+    public ApacheHttpdAgent(String name, String host, int port) throws ConfigurationException {
         super(GUID, VERSION);
         try {
             this.name = name;
-            this.url = new URL(HTTP, host, STATUS_URL);
+            this.url = new URL(HTTP, host, port, STATUS_URL);
 
             logger.info("started");
         } catch (MalformedURLException e) {

--- a/src/com/mblund/newRelic/apacheHttpd/ApacheHttpdAgentFactory.java
+++ b/src/com/mblund/newRelic/apacheHttpd/ApacheHttpdAgentFactory.java
@@ -18,12 +18,13 @@ public class ApacheHttpdAgentFactory extends AgentFactory {
         try {
             String name = (String) properties.get("name");
             String host = (String) properties.get("host");
+            int port = Integer.parseInt((String) properties.get("port"));
 
             if (name == null || host == null ) {
                 throw new ConfigurationException("'name' or 'host' cannot be null. Do you have a 'config/plugin.json' file?");
             }
 
-            return new ApacheHttpdAgent(name, host);
+            return new ApacheHttpdAgent(name, host,port);
         } catch (ClassCastException e) {
             throw new ConfigurationException(e);
         }


### PR DESCRIPTION
THis allows apache's that are behind load balancers using non-standard ports to override the use of port 80.
